### PR TITLE
API improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0-alpha] - 2024-03-29
+### Added
+ - new LatLon type definition for a (latitude, longitude) named tuple
+ - nzshm_common.constants.DEFAULT_RESOLUTION (0.001 degree)
+ - sorting for CodedLocation objects (N->S then W->E)
+ - get_location_grid and get_location_grid_names functions for grids
+ - get_location_list and get_location_list_names functions for location lists
+
+### Changed
+ - CodedLocation (and new LatLon) can be imported directly from nzshm_common
+ - several function signatures now use LatLon instead of Tuple[float, float]
+      - non-breaking change; they are functionally equivalent in runtime
+
+
 ## [0.7.0] - 2024-03-19
 ### Added
  - get_locations function

--- a/docs/api/constants.md
+++ b/docs/api/constants.md
@@ -1,0 +1,1 @@
+::: nzshm_common.constants

--- a/docs/api/grids/region_grid.md
+++ b/docs/api/grids/region_grid.md
@@ -1,0 +1,3 @@
+::: nzshm_common.grids.region_grid
+    options:
+        filters: ["!^_"]

--- a/docs/api/location/types.md
+++ b/docs/api/location/types.md
@@ -1,0 +1,3 @@
+::: nzshm_common.location.types
+    options:
+        filters: ["!^_"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
     - location (package):
       - location (module): api/location/location.md
       - CodedLocation (class): api/location/code_location.CodedLocation.md
+      - types (module): api/location/types.md
   - Contributing: contributing.md
   - Changelog: changelog.md
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - Installation: installation.md
   - Usage: usage.md
   - API Reference:
+    - constants: api/constants.md
     - location (package):
       - location (module): api/location/location.md
       - CodedLocation (class): api/location/code_location.CodedLocation.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,9 +13,11 @@ nav:
   - Usage: usage.md
   - API Reference:
     - constants: api/constants.md
+    - grids (package):
+      - region_grid (module): api/grids/region_grid.md
     - location (package):
-      - location (module): api/location/location.md
       - CodedLocation (class): api/location/code_location.CodedLocation.md
+      - location (module): api/location/location.md
       - types (module): api/location/types.md
   - Contributing: contributing.md
   - Changelog: changelog.md

--- a/nzshm_common/__init__.py
+++ b/nzshm_common/__init__.py
@@ -3,3 +3,7 @@ __email__ = 'nshm@gns.cri.nz'
 __version__ = '0.7.0'
 
 from .location import location
+
+# Common classes at the top level for convenience
+from .location.code_location import CodedLocation
+from .location.types import LatLon

--- a/nzshm_common/constants.py
+++ b/nzshm_common/constants.py
@@ -1,0 +1,10 @@
+"""
+Standard values that are useful in multiple places.
+"""
+
+DEFAULT_RESOLUTION = 0.001
+"""
+Default coordinate resolution in degrees.
+This is typically used for
+[`CodedLocation`](location/code_location.CodedLocation.md) values.
+"""

--- a/nzshm_common/grids/__init__.py
+++ b/nzshm_common/grids/__init__.py
@@ -1,1 +1,1 @@
-from .region_grid import RegionGrid, load_grid
+from .region_grid import RegionGrid, get_location_grid, get_location_grid_names, load_grid

--- a/nzshm_common/grids/io.py
+++ b/nzshm_common/grids/io.py
@@ -2,11 +2,12 @@ import base64
 import csv
 import io
 import zipfile
+from typing import List
 
 from nzshm_common.location.types import LatLon
 
 
-def latlon_from_base64_zip(b64_data: str) -> list:
+def latlon_from_base64_zip(b64_data: str) -> List[LatLon]:
     result = []
     byte_data = base64.b64decode(b64_data)
     data = io.BytesIO(byte_data)

--- a/nzshm_common/grids/io.py
+++ b/nzshm_common/grids/io.py
@@ -3,6 +3,8 @@ import csv
 import io
 import zipfile
 
+from nzshm_common.location.types import LatLon
+
 
 def latlon_from_base64_zip(b64_data: str) -> list:
     result = []
@@ -12,5 +14,5 @@ def latlon_from_base64_zip(b64_data: str) -> list:
         plain_bytes = io.BytesIO(fz.read("data"))
         reader = csv.reader(io.StringIO(plain_bytes.getvalue().decode("utf-8", "ignore")))
         for row in reader:
-            result.append((float(row[1]), float(row[0])))
+            result.append(LatLon(float(row[1]), float(row[0])))
     return result

--- a/nzshm_common/grids/region_grid.py
+++ b/nzshm_common/grids/region_grid.py
@@ -102,20 +102,21 @@ def get_location_grid(location_grid_name: str, resolution: float = DEFAULT_RESOL
 
 def get_location_grid_names() -> Iterable[str]:
     """
-    Return a list of valid region grids.
+    Return a collection of of valid region grids.
 
-    Returns member names from the RegionGrid Enum class.
+    Returns:
+        member names from the RegionGrid Enum class.
 
     Examples:
         >>> from nzshm_common import grids
         >>> grids.get_location_grid_names()
-        [
+        dict_keys([
             'NZ_0_1_NB_1_0',
             'NZ_0_1_NB_1_1',
             'NZ_0_2_NB_1_1',
             'WLG_0_01_nb_1_1',
             'WLG_0_05_nb_1_1'
-        ]
+        ])
     """
 
     return RegionGrid.__members__.keys()

--- a/nzshm_common/grids/region_grid.py
+++ b/nzshm_common/grids/region_grid.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from enum import Enum
 from functools import partial
-from typing import Iterable
+from typing import Iterable, List
 
 from nzshm_common.constants import DEFAULT_RESOLUTION
 from nzshm_common.grids.nz_0_1_nb_1_v0 import NZ01nb1v0
@@ -49,7 +49,7 @@ class RegionGrid(Enum):
         return self.grid.load()
 
 
-def load_grid(grid_name: str) -> list[LatLon]:
+def load_grid(grid_name: str) -> List[LatLon]:
     """
     Load values from a region grid as `LatLon` pairs.
 

--- a/nzshm_common/grids/region_grid.py
+++ b/nzshm_common/grids/region_grid.py
@@ -84,8 +84,8 @@ def get_location_grid(location_grid_name: str, resolution: float = DEFAULT_RESOL
         >>> from nzshm_common import grids
         >>> grids.get_location_grid("NZ_0_1_NB_1_0")
         [
-            CodedLocation(lat=-35.109, lon=173.262, resolution=0.001),
-            CodedLocation(lat=-35.22, lon=173.97, resolution=0.001),
+            CodedLocation(lat=-46.1, lon=166.4, resolution=0.001),
+            CodedLocation(lat=-46.0, lon=166.4, resolution=0.001)
             ...
         ]
     """

--- a/nzshm_common/grids/region_grid.py
+++ b/nzshm_common/grids/region_grid.py
@@ -1,12 +1,15 @@
 from collections import namedtuple
 from enum import Enum
-from typing import Tuple
+from functools import partial
+from typing import Iterable, Tuple
 
+from nzshm_common.constants import DEFAULT_RESOLUTION
 from nzshm_common.grids.nz_0_1_nb_1_v0 import NZ01nb1v0
 from nzshm_common.grids.nz_0_1_nb_1_v1 import NZ01nb1v1
 from nzshm_common.grids.nz_0_2_nb_1_1 import NZ_0_2_nb_1_1
 from nzshm_common.grids.wlg_0_01_nb_1_1 import WLG_0_01_nb_1_1
 from nzshm_common.grids.wlg_0_05_nb_1_1 import WLG_0_05_nb_1_1
+from nzshm_common.location.code_location import CodedLocation
 
 RegionGridEntry = namedtuple("RegionGridEntry", "region_name resolution neighbours grid version")
 
@@ -41,5 +44,11 @@ class RegionGrid(Enum):
         return self.grid.load()
 
 
-def load_grid(gri_name: str) -> Tuple[float, float]:
+def load_grid(gri_name: str) -> list[Tuple[float, float]]:
     return RegionGrid[gri_name].load()
+
+
+def get_grid_locations(location_grid_name: str, resolution=DEFAULT_RESOLUTION) -> Iterable[CodedLocation]:
+    grid_values = RegionGrid[location_grid_name].load()
+    coded_at_resolution = partial(CodedLocation.from_tuple, resolution=resolution)
+    return list(map(coded_at_resolution, grid_values))

--- a/nzshm_common/location/code_location.py
+++ b/nzshm_common/location/code_location.py
@@ -45,7 +45,7 @@ class CodedLocation:
 
         For arithmetic comparisons we expect:
 
-        * south comes before north
+        * north comes before south
         * when on the same latitude, west comes before east
 
         Note:
@@ -71,9 +71,9 @@ class CodedLocation:
         """
         lat_delta = self.lat - other.lat
         lon_delta = self.lon - other.lon
-        if lat_delta < 0:
+        if lat_delta > 0:
             return True
-        elif lat_delta > 0:
+        elif lat_delta < 0:
             return False
         elif lon_delta < 0:
             return True

--- a/nzshm_common/location/code_location.py
+++ b/nzshm_common/location/code_location.py
@@ -40,8 +40,31 @@ class CodedLocation:
         self._code = f"{self.lat:.{self.display_places}f}~{self.lon:.{self.display_places}f}"
 
     def __lt__(self, other: "CodedLocation"):
-        """Comparator to allow sorting for CodedLocations."""
-        return self.code < other.code
+        """
+        Less-than comparator to enable sorting for CodedLocations.
+
+        Note:
+            Coded locations at different resolutions are not considered
+            equal. Use `.as_tuple` to check for numerical equivalency.
+
+        Examples:
+            >>> origin = CodedLocation(-11.11, 111.11, resolution=0.001)
+            >>> origin == CodedLocation(-11.11, 111.11, resolution=0.001)  # Equal
+            True
+            >>> origin == CodedLocation(-11.11, 111.11, resolution=0.01)  # Wrong resolution
+            False
+
+            >>> origin < CodedLocation(-11.12, 111.11, resolution=0.001)  # South of origin
+            False
+            >>> origin < CodedLocation(-11.10, 111.11, resolution=0.001)  # North of origin
+            True
+            >>> origin < CodedLocation(-11.11, 111.10, resolution=0.001)  # West of origin
+            False
+            >>> origin < CodedLocation(-11.11, 111.12, resolution=0.001)  # East of origin
+            True
+
+        """
+        return (self.lat < other.lat) or (self.lon < other.lon)
 
     @property
     def as_tuple(self) -> LatLon:

--- a/nzshm_common/location/code_location.py
+++ b/nzshm_common/location/code_location.py
@@ -43,6 +43,11 @@ class CodedLocation:
         """
         Less-than comparator to enable sorting for CodedLocations.
 
+        For arithmetic comparisons we expect:
+
+        * south comes before north
+        * when on the same latitude, west comes before east
+
         Note:
             Coded locations at different resolutions are not considered
             equal. Use `.as_tuple` to check for numerical equivalency.
@@ -64,7 +69,16 @@ class CodedLocation:
             True
 
         """
-        return (self.lat < other.lat) or (self.lon < other.lon)
+        lat_delta = self.lat - other.lat
+        lon_delta = self.lon - other.lon
+        if lat_delta < 0:
+            return True
+        elif lat_delta > 0:
+            return False
+        elif lon_delta < 0:
+            return True
+        else:
+            return False
 
     @property
     def as_tuple(self) -> LatLon:
@@ -129,9 +143,13 @@ class CodedLocation:
         return CodedLocation(lat=location[0], lon=location[1], resolution=resolution)
 
     def resample(self, resolution: float) -> "CodedLocation":
-        """Downsample/Resample."""
+        """
+        Create a resampled CodedLocation with a finer resolution.
+        """
         return self.downsample(resolution)
 
     def downsample(self, resolution: float) -> "CodedLocation":
-        """Downsample/Resample."""
+        """
+        Create a downsampled CodedLocation with a coarser resolution.
+        """
         return CodedLocation(lat=self.lat, lon=self.lon, resolution=resolution)

--- a/nzshm_common/location/code_location.py
+++ b/nzshm_common/location/code_location.py
@@ -1,6 +1,8 @@
 import decimal
 from dataclasses import dataclass, field
 
+from nzshm_common.location.types import LatLon
+
 
 @dataclass(init=False, unsafe_hash=True)
 class CodedLocation:
@@ -35,6 +37,21 @@ class CodedLocation:
         self.resolution = resolution
 
         self._code = f"{self.lat:.{self.display_places}f}~{self.lon:.{self.display_places}f}"
+
+    @property
+    def as_tuple(self) -> LatLon:
+        """
+        Convert to a `LatLon(latitude, longitude)` named tuple.
+
+        Example:
+            ```py
+            >>> nzshm_common.location.get_locations(["CHC"])[0]
+            CodedLocation(lat=-43.53, lon=172.63, resolution=0.001)
+            >>> nzshm_common.location.get_locations(["CHC"])[0].as_tuple.latitude
+            -43.53
+            ```
+        """
+        return LatLon(self.lat, self.lon)
 
     @property
     def code(self) -> str:

--- a/nzshm_common/location/code_location.py
+++ b/nzshm_common/location/code_location.py
@@ -1,6 +1,5 @@
 import decimal
 from dataclasses import dataclass, field
-from typing import Tuple, Union
 
 from nzshm_common.constants import DEFAULT_RESOLUTION
 from nzshm_common.location.types import LatLon
@@ -40,6 +39,10 @@ class CodedLocation:
 
         self._code = f"{self.lat:.{self.display_places}f}~{self.lon:.{self.display_places}f}"
 
+    def __lt__(self, other: "CodedLocation"):
+        """Comparator to allow sorting for CodedLocations."""
+        return self.code < other.code
+
     @property
     def as_tuple(self) -> LatLon:
         """
@@ -47,9 +50,11 @@ class CodedLocation:
 
         Example:
             ```py
-            >>> nzshm_common.location.get_locations(["CHC"])[0]
+            >>> from nzshm_common import location
+            >>> location.get_locations(["CHC"])[0]
             CodedLocation(lat=-43.53, lon=172.63, resolution=0.001)
-            >>> nzshm_common.location.get_locations(["CHC"])[0].as_tuple.latitude
+            >>> latitude, longitude = location.get_locations(["CHC"])[0].as_tuple
+            >>> latitude
             -43.53
             ```
         """
@@ -63,9 +68,7 @@ class CodedLocation:
         return self._code
 
     @classmethod
-    def from_tuple(
-        cls, location: Union[LatLon, Tuple[float, float]], resolution: float = DEFAULT_RESOLUTION
-    ) -> "CodedLocation":
+    def from_tuple(cls, location: LatLon, resolution: float = DEFAULT_RESOLUTION) -> "CodedLocation":
         """
         Create a `CodedLocation` from a tuple.
 

--- a/nzshm_common/location/code_location.py
+++ b/nzshm_common/location/code_location.py
@@ -1,6 +1,8 @@
 import decimal
 from dataclasses import dataclass, field
+from typing import Tuple, Union
 
+from nzshm_common.constants import DEFAULT_RESOLUTION
 from nzshm_common.location.types import LatLon
 
 
@@ -59,6 +61,46 @@ class CodedLocation:
         The string code for the location expressed as latitude~longitude.
         """
         return self._code
+
+    @classmethod
+    def from_tuple(
+        cls, location: Union[LatLon, Tuple[float, float]], resolution: float = DEFAULT_RESOLUTION
+    ) -> "CodedLocation":
+        """
+        Create a `CodedLocation` from a tuple.
+
+        Parameters:
+            location: a structure containing a latitude and longitude, in that order
+            resolution: coordinate resolution in degrees
+
+        Examples:
+            Convert a single location:
+            >>> from nzshm_common import CodedLocation
+            >>> CodedLocation.from_tuple((-36.87, 174.77))
+            CodedLocation(lat=-36.87, lon=174.77, resolution=0.001)
+
+            >>> from nzshm_common import LatLon
+            >>> CodedLocation.from_tuple(LatLon(-36.87, 174.77))
+            CodedLocation(lat=-36.87, lon=174.77, resolution=0.001)
+
+            Convert a list of locations:
+            >>> location_list = [(-36.111, 174.111), (-36.222, 174.222)]
+            >>> list(map(CodedLocation.from_tuple, location_list))
+            [
+                CodedLocation(lat=-36.111, lon=174.111, resolution=0.001),
+                CodedLocation(lat=-36.222, lon=174.222, resolution=0.001)
+            ]
+
+            Convert a list of locations with a custom resolution:
+            >>> from functools import partial
+            >>> lo_res = partial(CodedLocation.from_tuple, resolution=0.1)
+            >>> list(map(lo_res, location_list))
+            [
+                CodedLocation(lat=-36.1, lon=174.1, resolution=0.1),
+                CodedLocation(lat=-36.2, lon=174.2, resolution=0.1)
+            ]
+        """
+        return CodedLocation(lat=location[0], lon=location[1], resolution=resolution)
 
     def resample(self, resolution: float) -> "CodedLocation":
         """Downsample/Resample."""

--- a/nzshm_common/location/location.py
+++ b/nzshm_common/location/location.py
@@ -16,11 +16,12 @@ import csv
 import json
 from collections import namedtuple
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional
 
 from nzshm_common.constants import DEFAULT_RESOLUTION
 from nzshm_common.grids.region_grid import load_grid
 from nzshm_common.location.code_location import CodedLocation
+from nzshm_common.location.types import LatLon
 
 # Omitting country for now, focus on NZ
 # https://service.unece.org/trade/locode/nz.htm
@@ -62,9 +63,10 @@ LOCATION_LISTS = {
 }
 
 
-def _lat_lon(_id) -> Optional[Tuple[float, float]]:
-    if location_by_id(_id):
-        return (location_by_id(_id)['latitude'], location_by_id(_id)['longitude'])  # type: ignore
+def _lat_lon(_id) -> Optional[LatLon]:
+    loc = location_by_id(_id)
+    if loc:
+        return LatLon(loc['latitude'], loc['longitude'])
     return None
 
 
@@ -184,7 +186,7 @@ def get_location_list(
         for loc in location_keyset
     ]
     if sort_locations:
-        return sorted(coded_locations, key=lambda x: x.code)
+        return sorted(coded_locations)
     else:
         return coded_locations
 

--- a/nzshm_common/location/location.py
+++ b/nzshm_common/location/location.py
@@ -139,7 +139,7 @@ def get_locations(locations: Iterable[str], resolution: float = DEFAULT_RESOLUTI
     return coded_locations
 
 
-def get_location_list_names() -> list[str]:
+def get_location_list_names() -> List[str]:
     """
     Return a list of valid location lists.
 
@@ -152,7 +152,7 @@ def get_location_list_names() -> list[str]:
 
 
 def get_location_list(
-    location_list_names: list[str], resolution: float = DEFAULT_RESOLUTION, sort_locations: bool = True
+    location_list_names: List[str], resolution: float = DEFAULT_RESOLUTION, sort_locations: bool = True
 ) -> Iterable[CodedLocation]:
     """
     Get all coded locations within one or more lists.

--- a/nzshm_common/location/location.py
+++ b/nzshm_common/location/location.py
@@ -18,6 +18,7 @@ from collections import namedtuple
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+from nzshm_common.constants import DEFAULT_RESOLUTION
 from nzshm_common.grids.region_grid import load_grid
 from nzshm_common.location.code_location import CodedLocation
 
@@ -95,7 +96,7 @@ def location_by_id(location_code: str) -> Optional[Dict[str, Any]]:
     return LOCATIONS_BY_ID.get(location_code)
 
 
-def get_locations(locations: Iterable[str], resolution: float = 0.001) -> List[CodedLocation]:
+def get_locations(locations: Iterable[str], resolution: float = DEFAULT_RESOLUTION) -> List[CodedLocation]:
     """
     Get the coded locations from a list of identifiers.
 
@@ -134,6 +135,58 @@ def get_locations(locations: Iterable[str], resolution: float = 0.001) -> List[C
                 raise KeyError(msg)
 
     return coded_locations
+
+
+def get_location_list_names() -> list[str]:
+    """
+    Return a list of valid location lists.
+
+    Examples:
+        >>> from nzshm_common import location
+        >>> location.get_location_list_names()
+        ['HB', 'NZ', 'NZ2', 'SRWG214', 'ALL']
+    """
+    return list(LOCATION_LISTS.keys())
+
+
+def get_location_list(
+    location_list_names: list[str], resolution: float = DEFAULT_RESOLUTION, sort_locations: bool = True
+) -> Iterable[CodedLocation]:
+    """
+    Get all coded locations within one or more lists.
+
+    Parameters:
+        location_list_names: a list of valid LOCATION_LIST keys
+        resolution: the resolution used by CodedLocation
+        sort_locations: (optional) whether to sort the CodedLocation values by code
+
+    Returns:
+        a list of coded locations
+
+
+    Examples:
+        >>> from nzshm_common import location
+        >>> get_location_list(["NZ", "SRWG214"])
+        [
+            CodedLocation(lat=-35.109, lon=173.262, resolution=0.001),
+            CodedLocation(lat=-35.22, lon=173.97, resolution=0.001),
+            ...
+        ]
+    """
+    # Merge location lists, ensuring unique keys.
+    location_keyset = set([loc for name in location_list_names for loc in LOCATION_LISTS[name]["locations"]])
+    coded_locations = [
+        CodedLocation(
+            lat=LOCATIONS_BY_ID[loc]["latitude"],
+            lon=LOCATIONS_BY_ID[loc]["longitude"],
+            resolution=resolution,
+        )
+        for loc in location_keyset
+    ]
+    if sort_locations:
+        return sorted(coded_locations, key=lambda x: x.code)
+    else:
+        return coded_locations
 
 
 if __name__ == "__main__":

--- a/nzshm_common/location/location.py
+++ b/nzshm_common/location/location.py
@@ -166,7 +166,7 @@ def get_location_list(
 
     Examples:
         >>> from nzshm_common import location
-        >>> get_location_list(["NZ", "SRWG214"])
+        >>> location.get_location_list(["NZ", "SRWG214"])
         [
             CodedLocation(lat=-35.109, lon=173.262, resolution=0.001),
             CodedLocation(lat=-35.22, lon=173.97, resolution=0.001),

--- a/nzshm_common/location/location.py
+++ b/nzshm_common/location/location.py
@@ -1,5 +1,5 @@
 """
-This module contains constants and functions for refereing to location or list of locations by an identifier
+This module contains constants and functions for referring to location or list of locations by an identifier.
 
 Constants:
     LOCATION_LISTS - a dictionary of location lists
@@ -80,7 +80,7 @@ def _load_csv(locations_filepath, resolution):
 
 def location_by_id(location_code: str) -> Optional[Dict[str, Any]]:
     """
-    Get the CodedLocation for a locatation identified by an id.
+    Get the CodedLocation for a location identified by an id.
 
     Parameters:
         location_code: the code (e.g. "WLG") for the location

--- a/nzshm_common/location/location.py
+++ b/nzshm_common/location/location.py
@@ -157,14 +157,16 @@ def get_location_list(
     """
     Get all coded locations within one or more lists.
 
+    The sorting method used for CodedLocation values is described in
+    [`CodedLocation.__lt__`](../code_location.CodedLocation/#nzshm_common.location.code_location.CodedLocation.__lt__)
+
     Parameters:
         location_list_names: a list of valid LOCATION_LIST keys
         resolution: the resolution used by CodedLocation
-        sort_locations: (optional) whether to sort the CodedLocation values by code
+        sort_locations: (optional) whether to sort the CodedLocation values
 
     Returns:
         a list of coded locations
-
 
     Examples:
         >>> from nzshm_common import location

--- a/nzshm_common/location/types.py
+++ b/nzshm_common/location/types.py
@@ -12,9 +12,12 @@ from typing import NamedTuple
 
 class LatLon(NamedTuple):
     """
-    A lightweight type for `(latitude, longitude)` pairs.
+    A lightweight type for `(latitude, longitude)` float pairs.
+
+    This is a named tuple with latitude and longitude fields.
 
     Examples:
+        ```py
         >>> wlg = LatLon(-41.3, 174.78)
         >>> wlg
         LatLon(latitude=-41.3, longitude=174.78)
@@ -22,6 +25,7 @@ class LatLon(NamedTuple):
         -41.3
         >>> wlg[0]
         -41.3
+        ```
     """
 
     latitude: float

--- a/nzshm_common/location/types.py
+++ b/nzshm_common/location/types.py
@@ -1,0 +1,31 @@
+"""
+This module contains common type definitions.
+
+When imported from an external package, the types defined here should also be
+available at the top level of the package, e.g.:
+
+    >>> from nzshm_common import LatLon
+"""
+
+from typing import NamedTuple
+
+
+class LatLon(NamedTuple):
+    """
+    A lightweight type for `(latitude, longitude)` pairs.
+
+    Examples:
+        >>> wlg = LatLon(-41.3, 174.78)
+        >>> wlg
+        LatLon(latitude=-41.3, longitude=174.78)
+        >>> wlg.latitude
+        -41.3
+        >>> wlg[0]
+        -41.3
+    """
+
+    latitude: float
+    longitude: float
+
+
+LatLon.__module__ = "nzshm_common"

--- a/scripts/locations_to_oq.py
+++ b/scripts/locations_to_oq.py
@@ -1,13 +1,12 @@
 import argparse
 import csv
-
 from enum import Enum
 from pathlib import Path
 
 from shapely.geometry import Point
 
-from nzshm_common.location.location import LOCATIONS_BY_ID, LOCATIONS_SRWG214_BY_ID
 from nzshm_common.geometry.geometry import create_backarc_polygon
+from nzshm_common.location.location import LOCATIONS_BY_ID, LOCATIONS_SRWG214_BY_ID
 
 
 class SiteLists(Enum):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,9 @@
+from contextlib import contextmanager
+
+
+@contextmanager
+def does_not_raise():
+    """
+    Helper class for writing parameterized tests that might cause exceptions.
+    """
+    yield

--- a/tests/test_backarc.py
+++ b/tests/test_backarc.py
@@ -3,6 +3,7 @@ import unittest
 try:
     import shapely  # noqa
     from shapely.geometry import Point
+
     from nzshm_common.geometry.geometry import backarc_polygon
 
     HAVE_SHAPELY = True

--- a/tests/test_coded_location.py
+++ b/tests/test_coded_location.py
@@ -82,7 +82,7 @@ def test_coded_location_helper():
 
 
 @pytest.mark.parametrize("lat,lon,expected", oh_point_five_expected)
-def test_downsample_default_oh_point_five_no_downsampking_required(lat, lon, expected):
+def test_downsample_default_oh_point_five_no_downsampling_required(lat, lon, expected):
     print(f"lat {lat} lon {lon} -> {expected}")
     assert CodedLocation(lat, lon, 0.5).code == expected
 

--- a/tests/test_coded_location.py
+++ b/tests/test_coded_location.py
@@ -84,17 +84,17 @@ def test_coded_location_from_tuple():
 @pytest.mark.parametrize(
     "lat,lon,is_before,is_code_before,description",
     [
-        (-45.1, +171.3, 0, 1, "0.1 North 0.1 West"),
-        (-45.1, +171.4, 0, 1, "0.1 North"),
-        (-45.1, +171.5, 0, 1, "0.1 North 0.1 East"),
+        (-45.1, +171.3, 1, 1, "0.1 North 0.1 West"),
+        (-45.1, +171.4, 1, 1, "0.1 North"),
+        (-45.1, +171.5, 1, 1, "0.1 North 0.1 East"),
         (-45.2, +171.3, 1, 1, "0.1 West"),
-        (-45.2, +171.4, 0, 0, "Reference"),
+        (-45.2, +171.4, 0, 0, "Reference (in Southern/Eastern Hemispheres)"),
         (-45.2, +171.5, 0, 0, "0.1 East"),
-        (-45.3, +171.3, 1, 0, "0.1 South 0.1 West"),
-        (-45.3, +171.4, 1, 0, "0.1 South"),
-        (-45.3, +171.5, 1, 0, "0.1 South 0.1 East"),
-        (+45.2, -171.4, 0, 0, "Northern / Western Hemispheres"),
-        (+45.2, +171.4, 0, 0, "Northern / Eastern Hemispheres"),
+        (-45.3, +171.3, 0, 0, "0.1 South 0.1 West"),
+        (-45.3, +171.4, 0, 0, "0.1 South"),
+        (-45.3, +171.5, 0, 0, "0.1 South 0.1 East"),
+        (+45.2, -171.4, 1, 0, "Northern / Western Hemispheres (code sort inverts lat)"),
+        (+45.2, +171.4, 1, 0, "Northern / Eastern Hemispheres (code sort inverts lat)"),
         (-45.2, -171.4, 1, 1, "Southern / Western Hemispheres"),
     ],
 )
@@ -103,11 +103,13 @@ def test_coded_location_ordering(lat, lon, is_before, is_code_before, descriptio
     Characterising differences in sorting arithmetically by latitude then
     longitude, versus alphanumeric .code sorting.
 
-    For arithmetic comparisons we expect:
-    - South before North, or
-    - West before East when on the same latitude
+    Alpha sorting works for New Zealand because we have a negative latitude,
+    but would sort in the opposite direction for the northern hemisphere.
 
-    For code comparisons, alphanumeric sorting puts "-45.1" ahead of "-45.2".
+    For arithmetic comparisons we expect:
+
+    - North before Sorth, or
+    - West before East when on the same latitude
     """
     reference_point = CodedLocation(-45.24, 171.4, 0.1)
     is_before = bool(is_before)

--- a/tests/test_coded_location.py
+++ b/tests/test_coded_location.py
@@ -4,6 +4,7 @@ import unittest
 import pytest
 
 from nzshm_common import CodedLocation, LatLon
+from nzshm_common.constants import DEFAULT_RESOLUTION
 from nzshm_common.grids.region_grid import load_grid
 from tests.helpers import does_not_raise
 
@@ -64,6 +65,19 @@ def test_coded_location_equality(lat, lon, expected):
     c0 = CodedLocation(lat, lon, 0.5)
     c1 = CodedLocation(lat, lon, 0.5)
     assert c0 == c1
+
+
+def test_coded_location_helper():
+    coded_loc = CodedLocation.from_tuple((-45.27, 171.14))
+    assert isinstance(coded_loc, CodedLocation), "Return type should be CodedLocation"
+    assert coded_loc.resolution == DEFAULT_RESOLUTION, "Should have default resolution"
+    assert coded_loc.lat == -45.27, "Latitude should match"
+    assert coded_loc.lon == 171.14, "Longitude should match"
+
+    coded_loc_lores = CodedLocation.from_tuple((-45.27, 171.14), resolution=0.1)
+    assert coded_loc_lores.resolution == 0.1, "Should have lowered resolution"
+    assert coded_loc_lores.lat == -45.3, "Should have rounded latitude"
+    assert coded_loc_lores.lon == 171.1, "Should have rounded longitude"
 
 
 @pytest.mark.parametrize("lat,lon,expected", oh_point_five_expected)

--- a/tests/test_coded_location.py
+++ b/tests/test_coded_location.py
@@ -68,12 +68,13 @@ def test_coded_location_equality(lat, lon, expected):
 
 
 def test_coded_location_helper():
-    coded_loc = CodedLocation.from_tuple((-45.27, 171.14))
+    coded_loc = CodedLocation.from_tuple(LatLon(latitude=-45.27, longitude=171.14))
     assert isinstance(coded_loc, CodedLocation), "Return type should be CodedLocation"
     assert coded_loc.resolution == DEFAULT_RESOLUTION, "Should have default resolution"
     assert coded_loc.lat == -45.27, "Latitude should match"
     assert coded_loc.lon == 171.14, "Longitude should match"
 
+    # A naked (latitude, longitude) tuple with the same values should work also.
     coded_loc_lores = CodedLocation.from_tuple((-45.27, 171.14), resolution=0.1)
     assert coded_loc_lores.resolution == 0.1, "Should have lowered resolution"
     assert coded_loc_lores.lat == -45.3, "Should have rounded latitude"

--- a/tests/test_coded_location.py
+++ b/tests/test_coded_location.py
@@ -3,9 +3,8 @@ import unittest
 
 import pytest
 
+from nzshm_common import CodedLocation, LatLon
 from nzshm_common.grids.region_grid import load_grid
-from nzshm_common.location import CodedLocation
-
 from tests.helpers import does_not_raise
 
 GRID_02 = load_grid('NZ_0_2_NB_1_1')
@@ -48,6 +47,16 @@ oh_point_five_expected = [
     (-45.27, 171.8, '-45.5~172.0'),
     (-41.3, 174.783, '-41.5~175.0'),  # WLG
 ]
+
+
+def test_as_tuple():
+    c = CodedLocation(-45.2, 175.2, 0.1)
+
+    assert isinstance(c.as_tuple, LatLon)
+    assert c.as_tuple.latitude == -45.2
+    assert c.as_tuple.longitude == 175.2
+    assert c.as_tuple[0] == -45.2
+    assert c.as_tuple[1] == 175.2
 
 
 @pytest.mark.parametrize("lat,lon,expected", oh_point_five_expected)

--- a/tests/test_coded_location.py
+++ b/tests/test_coded_location.py
@@ -1,10 +1,12 @@
-from contextlib import contextmanager
-import pytest
+import random
 import unittest
 
-from nzshm_common.location import CodedLocation
+import pytest
+
 from nzshm_common.grids.region_grid import load_grid
-import random
+from nzshm_common.location import CodedLocation
+
+from tests.helpers import does_not_raise
 
 GRID_02 = load_grid('NZ_0_2_NB_1_1')
 LOCS = [CodedLocation(loc[0], loc[1], 0.001) for loc in GRID_02[20:50]]  # type: ignore
@@ -111,11 +113,6 @@ def test_downsample_oh_point_one(lat, lon, expected):
 def test_downsample_oh_point_oh_five(lat, lon, expected):
     c = CodedLocation(lat, lon, 0.05)
     assert c.downsample(0.05).code == expected
-
-
-@contextmanager
-def does_not_raise():
-    yield
 
 
 @pytest.mark.parametrize(

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,11 +1,11 @@
-import string
+import os
 import random
+import string
 import tempfile
 import zipfile
-import os
-
 from pathlib import Path
-from nzshm_common.util import compress_string, decompress_string, compress_path
+
+from nzshm_common.util import compress_path, compress_string, decompress_string
 
 
 def test_string_compression_round_trip():

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,10 +1,11 @@
-import unittest
 import math
+import unittest
 
-from nzshm_common.grids import load_grid, RegionGrid
+from nzshm_common.grids import RegionGrid, load_grid
 
 try:
     import shapely  # noqa
+
     from nzshm_common.geometry.geometry import create_hexagon, create_square_tile  # these require shapely
 
     HAVE_SHAPELY = True

--- a/tests/test_get_location_list.py
+++ b/tests/test_get_location_list.py
@@ -23,11 +23,23 @@ def test_multiple_sources():
     merged_locations = set(LOCATION_LISTS["NZ"]["locations"] + LOCATION_LISTS["SRWG214"]["locations"])
     assert len(location_list) == len(merged_locations), "List length equalling merge of two lists"
 
-    # Ensure nothing weird happens if we include a list twice
-    location_list = get_location_list(["NZ", "NZ"], sort_locations=False)
-    assert len(location_list) == len(
-        LOCATION_LISTS["NZ"]["locations"]
-    ), "Should match count for single NZ location list"
+
+def test_source_overlaps():
+    """
+    Ensure that locations that appear in multiple lists are not duplicated.
+    """
+    nznz_list = get_location_list(["NZ", "NZ"])
+    assert len(nznz_list) == len(LOCATION_LISTS["NZ"]["locations"]), "Should match count for single NZ location list"
+
+    masterton = get_locations(["MRO"])[0]
+    # Turning off sort_locations to make the test marginally faster for larger collections.
+    nz_list = get_location_list(["NZ"], sort_locations=False)
+    all_list = get_location_list(["ALL"], sort_locations=False)
+    nz_all_list = get_location_list(["NZ", "ALL"], sort_locations=False)
+
+    assert nz_list.count(masterton) == 1, "Should find Masterton in New Zealand once"
+    assert all_list.count(masterton) == 1, "Should find Masterton in All once"
+    assert nz_all_list.count(masterton) == 1, "Should find Masterton in combined list once"
 
 
 def test_missing_source():

--- a/tests/test_get_location_list.py
+++ b/tests/test_get_location_list.py
@@ -1,0 +1,51 @@
+import pytest
+
+from nzshm_common.location.location import DEFAULT_RESOLUTION, LOCATION_LISTS, get_location_list, get_locations
+
+
+def test_single_source():
+    location_list = get_location_list(["NZ"])
+    assert len(location_list) == len(LOCATION_LISTS["NZ"]["locations"]), "Should match count for NZ locations"
+
+    location_list_codes = [loc.code for loc in location_list]
+    assert get_locations(["AKL"])[0].code in location_list_codes, "Should find Auckland"
+    assert get_locations(["DUD"])[0].code in location_list_codes, "Should find Dunedin"
+
+
+def test_multiple_sources():
+    location_list = get_location_list(["NZ", "SRWG214"])
+    merged_locations = set(LOCATION_LISTS["NZ"]["locations"] + LOCATION_LISTS["SRWG214"]["locations"])
+    assert len(location_list) == len(merged_locations), "List length equalling merge of two lists"
+
+    # Ensure nothing weird happens if we include a list twice
+    location_list = get_location_list(["NZ", "NZ"])
+    assert len(location_list) == len(
+        LOCATION_LISTS["NZ"]["locations"]
+    ), "Should match count for single NZ location list"
+
+
+def test_missing_source():
+    with pytest.raises(KeyError):
+        get_location_list(["unknown"])
+
+    with pytest.raises(KeyError):
+        get_location_list(["NZ", "unknown"])
+
+    location_list = get_location_list([])
+    assert len(location_list) == 0, "Should be an empty list"
+
+
+def test_resolution_override():
+    custom_resolution = 0.1
+    assert DEFAULT_RESOLUTION != custom_resolution, "Tested resolutions should be different"
+
+    location_list = get_location_list(["NZ"], resolution=custom_resolution)
+    assert len(location_list) == len(LOCATION_LISTS["NZ"]["locations"]), "Should match count for NZ locations"
+
+    location_list_codes = [loc.code for loc in location_list]
+    assert (
+        get_locations(["AKL"])[0].code not in location_list_codes
+    ), "Should not find Auckland code at default resolution"
+    assert (
+        get_locations(["AKL"], resolution=custom_resolution)[0].code in location_list_codes
+    ), "Should find Auckland code at custom resolution"

--- a/tests/test_get_location_list.py
+++ b/tests/test_get_location_list.py
@@ -1,6 +1,12 @@
 import pytest
 
-from nzshm_common.location.location import DEFAULT_RESOLUTION, LOCATION_LISTS, get_location_list, get_locations
+from nzshm_common.location.location import (
+    DEFAULT_RESOLUTION,
+    LOCATION_LISTS,
+    get_location_list,
+    get_location_list_names,
+    get_locations,
+)
 
 
 def test_single_source():
@@ -18,7 +24,7 @@ def test_multiple_sources():
     assert len(location_list) == len(merged_locations), "List length equalling merge of two lists"
 
     # Ensure nothing weird happens if we include a list twice
-    location_list = get_location_list(["NZ", "NZ"])
+    location_list = get_location_list(["NZ", "NZ"], sort_locations=False)
     assert len(location_list) == len(
         LOCATION_LISTS["NZ"]["locations"]
     ), "Should match count for single NZ location list"
@@ -49,3 +55,10 @@ def test_resolution_override():
     assert (
         get_locations(["AKL"], resolution=custom_resolution)[0].code in location_list_codes
     ), "Should find Auckland code at custom resolution"
+
+
+def test_names():
+    name_list = get_location_list_names()
+    assert "NZ" in name_list, "Should contain NZ location list"
+    assert "SRWG214" in name_list, "Should contain SRWG214 location list"
+    assert "NZ_0_1_NB_1_0" not in name_list, "Should not include grid names"

--- a/tests/test_get_locations.py
+++ b/tests/test_get_locations.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from nzshm_common.location.location import get_locations, LOCATION_LISTS
 from nzshm_common.location.code_location import CodedLocation
+from nzshm_common.location.location import LOCATION_LISTS, get_locations
 
 LOCATIONS_FILEPATH = Path(__file__).parent / 'fixtures' / 'location_file.csv'
 

--- a/tests/test_get_locations.py
+++ b/tests/test_get_locations.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from nzshm_common.location.code_location import CodedLocation
 from nzshm_common.location.location import LOCATION_LISTS, get_locations
 
@@ -30,3 +32,22 @@ def test_csv():
 
 def test_mix():
     assert len(get_locations(["NZ", LOCATIONS_FILEPATH])) == 2 + len(LOCATION_LISTS["NZ"]["locations"])
+
+
+def test_code():
+    """Test for lat~lon code format."""
+    expected = [
+        CodedLocation(-41.2, 100.2, 0.001),
+        CodedLocation(-30.5, 99, 0.001),
+    ]
+    assert (
+        get_locations(["-41.200~100.200", "-30.500~99.000"]) == expected
+    ), "Should work with codes at default resolution"
+    assert (
+        get_locations(["-41.2~100.2", "-30.5~99"]) == expected
+    ), "Should work when code resolution doesn't exactly match, as long as values are correct"
+
+
+def test_missing_location_name():
+    with pytest.raises(KeyError, match="location missing_name is not a valid location identifier"):
+        get_locations(["missing_name"])

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -50,3 +50,7 @@ def test_rounded_locations():
 
     id = 'srg_186'
     assert CodedLocation(*get_lat_lon(id), 0.001).code == "-44.379~171.230"
+
+
+def test_missing_lat_lon_returns_None():
+    assert location._lat_lon("missingid") is None, "An unknown ID should return a None"

--- a/tests/test_region_grid.py
+++ b/tests/test_region_grid.py
@@ -1,7 +1,7 @@
 from typing import Iterable
 
 from nzshm_common.constants import DEFAULT_RESOLUTION
-from nzshm_common.grids import get_location_grid, load_grid
+from nzshm_common.grids import get_location_grid, get_location_grid_names, load_grid
 from nzshm_common.location import CodedLocation
 
 
@@ -84,3 +84,11 @@ def test_get_location_grid_downsampling():
     assert (
         grid_downsampled[0].as_tuple == resample.as_tuple
     ), "CodedLocations at different resolutions can be compared as LatLon values"
+
+
+def test_get_location_grid_names():
+    name_list = get_location_grid_names()
+    assert isinstance(name_list, Iterable), "Should be Iterable type"
+    assert "NZ_0_1_NB_1_0" in name_list, "Should include NZ_... grids"
+    assert "WLG_0_01_nb_1_1" in name_list, "Should include WLG_... grids"
+    assert "SRWG214" not in name_list, "Should not include location list names"

--- a/tests/test_region_grid.py
+++ b/tests/test_region_grid.py
@@ -1,4 +1,8 @@
-from nzshm_common.grids import load_grid
+from typing import Iterable
+
+from nzshm_common.constants import DEFAULT_RESOLUTION
+from nzshm_common.grids import get_location_grid, load_grid
+from nzshm_common.location import CodedLocation
 
 
 def test_load_wlg_0_005():
@@ -14,7 +18,7 @@ def test_load_nz_0_1():
 
 
 def test_load_lat_lon_order_spacing():
-    """Corordinate order must be lat, lon."""
+    """Coordinate order must be lat, lon."""
     grid = load_grid('NZ_0_1_NB_1_0')
     assert grid[0] == (-46.1, 166.4)
     assert grid[1] == (-46.0, 166.4)
@@ -36,3 +40,47 @@ def test_load_lat_lon_order_spacing():
     assert grid[0] == (-41.36, 174.69)
     assert grid[1] == (-41.35, 174.69)
     assert grid[2] == (-41.34, 174.69)
+
+
+def test_get_location_grid_default():
+    """Test get_location_grid with standard default resolution."""
+    # LatLons for comparison
+    baseline_grid = load_grid("WLG_0_05_nb_1_1")
+
+    grid_list = get_location_grid("WLG_0_05_nb_1_1")
+
+    assert isinstance(grid_list, Iterable), "Should be Iterable"
+    assert isinstance(grid_list[0], CodedLocation), "Should contain CodedLocation values"
+    assert grid_list[0].resolution == DEFAULT_RESOLUTION, "Should have default resolution"
+
+    assert len(grid_list) == len(baseline_grid), "Should have a CodedLocation for each grid coordinate"
+    assert grid_list[0].as_tuple == baseline_grid[0], "Preserving grid ordering"
+    assert grid_list[1].as_tuple == baseline_grid[1], "Preserving grid ordering"
+    assert grid_list[2].as_tuple == baseline_grid[2], "Preserving grid ordering"
+
+
+def test_get_location_grid_downsampling():
+    """Test behaviours of get_location_grid when setting a lower resolution."""
+    # Load at default resolution for comparison
+    grid_list = get_location_grid("WLG_0_05_nb_1_1")
+
+    grid_downsampled = get_location_grid("WLG_0_05_nb_1_1", resolution=0.1)
+    assert isinstance(grid_downsampled, Iterable), "Should be Iterable"
+    assert isinstance(grid_downsampled[0], CodedLocation), "Should contain CodedLocation values"
+    assert len(grid_list) > len(grid_downsampled), "Should have fewer downsampled coordinates"
+
+    assert grid_list[0].as_tuple == (-41.4, 174.65), "Baseline value 0"
+    # -- Skipped duplicated grid point --
+    assert grid_list[2].as_tuple == (-41.3, 174.65), "Baseline value 2"
+    # -- Skipped duplicated grid point --
+    assert grid_list[4].as_tuple == (-41.35, 174.7), "Baseline value 4"
+
+    assert grid_downsampled[0].as_tuple == (-41.4, 174.6), "Downsampled value 0"
+    assert grid_downsampled[1].as_tuple == (-41.3, 174.6), "Downsampled value 1"
+    assert grid_downsampled[2].as_tuple == (-41.4, 174.7), "Downsampled value 2"
+
+    resample = grid_downsampled[0].resample(0.001)
+    assert grid_downsampled[0] != resample, "Same locations at different resolutions are not considered equal"
+    assert (
+        grid_downsampled[0].as_tuple == resample.as_tuple
+    ), "CodedLocations at different resolutions can be compared as LatLon values"


### PR DESCRIPTION
Closes #38:

## Types and defaults
- Added `nzshm_common.constants` for DEFAULT_RESOLUTION value
- Added `nzshm_common.location.types` for an explicit `LatLon` named tuple type
- Refactoring earlier `Tuple[float, float]` type signatures to specify `LatLon`
    -  (As far as mypy is concerned, it's the same picture.)
- `CodedLocation` and `LatLon` are now importable directly from `nzshm_common`

## New functionality
- Added `as_tuple` and `from_tuple` to `CodedLocation`
- Added a dunder `__lt__` method to allow sorting `CodedLocation` objects directly (rather than by `code` field)
- Added `get_location_list` and `get_location_list_names` to `location.location`
- Added `get_location_grid` and `get_location_grid_names` to `grids.region_grid`

## Housekeeping
- A variety of documentation strings and typo fixups
- Included `grids.region_grid` in docs config
- A variety of tests for improved coverage
- `does_not_raise` test context manager moved into `tests/helpers.py` for reuse in exception testing
- Moving around a few imports (I ran `isort` at the repo root)
