### PR TITLE
Feature/60 location list api

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.10.0
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2025-12-05
+### Added
+ - function `get_location_ids` to get loction ids from location list names
+ - function `get_location_dicts` to get location ids, names, and coordinates from location list names.
+
 ## [0.9.0] - 2025-10-13
 ### Changed
 - migrated `pyproject.toml` to [PEP 508](https://peps.python.org/pep-0508) as per poetry v2.2 docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.0] - 2025-12-05
 ### Added
  - function `get_location_ids` to get loction ids from location list names
- - function `get_location_dicts` to get location ids, names, and coordinates from location list names.
+ - function `get_location_data` to get location ids, names, coordinates, and (optional) vs30 from location list names.
 
 ## [0.9.0] - 2025-10-13
 ### Changed

--- a/nzshm_common/__init__.py
+++ b/nzshm_common/__init__.py
@@ -1,6 +1,6 @@
 __author__ = "GNS Science"
 __email__ = 'nshm@gns.cri.nz'
-__version__ = '0.9.0'
+__version__ = '0.10.0'
 
 
 # Common classes at the top level for convenience

--- a/nzshm_common/location/__init__.py
+++ b/nzshm_common/location/__init__.py
@@ -25,4 +25,11 @@ Example:
 """
 
 from .coded_location import CodedLocation, CodedLocationBin
-from .location import get_location_list, get_location_list_names, get_locations, get_name_with_macrons, location_by_id
+from .location import (
+    get_location_ids,
+    get_location_list,
+    get_location_list_names,
+    get_locations,
+    get_name_with_macrons,
+    location_by_id,
+)

--- a/nzshm_common/location/__init__.py
+++ b/nzshm_common/location/__init__.py
@@ -26,6 +26,8 @@ Example:
 
 from .coded_location import CodedLocation, CodedLocationBin
 from .location import (
+    Location,
+    get_location_data,
     get_location_ids,
     get_location_list,
     get_location_list_names,

--- a/nzshm_common/location/location.py
+++ b/nzshm_common/location/location.py
@@ -3,10 +3,10 @@ This module contains constants and functions for referring to location or list o
 """
 
 import csv
-from dataclasses import dataclass
 import importlib.resources as resources
 import json
 from collections import namedtuple
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -18,8 +18,11 @@ from nzshm_common.location.types import LatLon
 # Omitting country for now, focus on NZ
 # https://service.unece.org/trade/locode/nz.htm
 
+
 @dataclass(frozen=True)
 class Location:
+    """Data class for location information stored in package resources."""
+
     id: str
     name: str
     latitude: float

--- a/nzshm_common/location/location.py
+++ b/nzshm_common/location/location.py
@@ -151,24 +151,46 @@ def location_by_id(location_code: str) -> Optional[Dict[str, Any]]:
     return LOCATIONS_BY_ID.get(location_code)
 
 
-def get_location_ids(location_list_name: str) -> List[str]:
+def get_location_ids(location_list_names: Iterable[str]) -> List[str]:
     """
-    Get a list of location ids for a given location list.
+    Get a list of location ids for given location list names.
 
     Valid location list names can be found using `get_location_list_names()`.
 
     Args:
-        location_list_name: a key in LOCATION_LISTS
+        location_list_names: an iterable of LOCATION_LISTS keys.
 
     Returns:
         A list of location ids for the given location list.
 
     Raises:
-        KeyError: if the location list name is not valid
+        KeyError: if a location list name is not valid
     """
-    if not LOCATION_LISTS.get(location_list_name):
-        raise KeyError(f"location list {location_list_name} is not valid")
-    return LOCATION_LISTS[location_list_name]["locations"]
+    ids = []
+    for list_name in location_list_names:
+        if not LOCATION_LISTS.get(list_name):
+            raise KeyError(f"location list {list_name} is not valid")
+        ids += LOCATION_LISTS[list_name]["locations"]
+    return ids
+
+
+def get_location_dicts(location_list_names: Iterable[str]) -> List[Dict[str, Any]]:
+    """
+    Get the full location data for given location list names.
+
+    Valid location list names can be found using `get_location_list_names()`.
+    A location dictionary contains the location id, name, latitude, and longitude.
+
+    Args:
+        location_list_names: an iterable of LOCATION_LISTS keys.
+
+    Returns:
+        A list of location data dictionaries for the given location list.
+
+    Raises:
+        KeyError: if a location list name is not valid
+    """
+    return [LOCATIONS_BY_ID[loc_id] for loc_id in get_location_ids(location_list_names)]
 
 
 def get_locations(locations: Iterable[str], resolution: float = DEFAULT_RESOLUTION) -> List[CodedLocation]:

--- a/nzshm_common/location/location.py
+++ b/nzshm_common/location/location.py
@@ -3,6 +3,7 @@ This module contains constants and functions for referring to location or list o
 """
 
 import csv
+from dataclasses import dataclass
 import importlib.resources as resources
 import json
 from collections import namedtuple
@@ -16,6 +17,15 @@ from nzshm_common.location.types import LatLon
 
 # Omitting country for now, focus on NZ
 # https://service.unece.org/trade/locode/nz.htm
+
+@dataclass(frozen=True)
+class Location:
+    id: str
+    name: str
+    latitude: float
+    longitude: float
+    vs30: Optional[float] = None
+
 
 resource_dir = resources.files('nzshm_common.location.resources')
 
@@ -174,7 +184,7 @@ def get_location_ids(location_list_names: Iterable[str]) -> List[str]:
     return ids
 
 
-def get_location_dicts(location_list_names: Iterable[str]) -> List[Dict[str, Any]]:
+def get_location_data(location_list_names: Iterable[str]) -> List[Location]:
     """
     Get the full location data for given location list names.
 
@@ -185,12 +195,12 @@ def get_location_dicts(location_list_names: Iterable[str]) -> List[Dict[str, Any
         location_list_names: an iterable of LOCATION_LISTS keys.
 
     Returns:
-        A list of location data dictionaries for the given location list.
+        A list of location data for the given location list.
 
     Raises:
         KeyError: if a location list name is not valid
     """
-    return [LOCATIONS_BY_ID[loc_id] for loc_id in get_location_ids(location_list_names)]
+    return [Location(**LOCATIONS_BY_ID[loc_id]) for loc_id in get_location_ids(location_list_names)]
 
 
 def get_locations(locations: Iterable[str], resolution: float = DEFAULT_RESOLUTION) -> List[CodedLocation]:

--- a/nzshm_common/location/location.py
+++ b/nzshm_common/location/location.py
@@ -151,6 +151,26 @@ def location_by_id(location_code: str) -> Optional[Dict[str, Any]]:
     return LOCATIONS_BY_ID.get(location_code)
 
 
+def get_location_ids(location_list_name: str) -> List[str]:
+    """
+    Get a list of location ids for a given location list.
+
+    Valid location list names can be found using `get_location_list_names()`.
+
+    Args:
+        location_list_name: a key in LOCATION_LISTS
+
+    Returns:
+        A list of location ids for the given location list.
+
+    Raises:
+        KeyError: if the location list name is not valid
+    """
+    if not LOCATION_LISTS.get(location_list_name):
+        raise KeyError(f"location list {location_list_name} is not valid")
+    return LOCATION_LISTS[location_list_name]["locations"]
+
+
 def get_locations(locations: Iterable[str], resolution: float = DEFAULT_RESOLUTION) -> List[CodedLocation]:
     """
     Get the coded locations from a list of identifiers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nzshm-common"
-version = "0.9.0"
+version = "0.10.0"
 description = "A small pure python library for shared NZ NSHM data like locations."
 readme = "README.md"
 homepage = "https://github.com/GNS-Science/nzshm-common-py"

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -86,7 +86,24 @@ def test_macron_mapping(name_in, name_out):
 
 def test_get_location_ids():
     for location_list_name in location.get_location_list_names():
-        assert location.get_location_ids(location_list_name) == location.LOCATION_LISTS[location_list_name]['locations']
+        assert (
+            location.get_location_ids([location_list_name]) == location.LOCATION_LISTS[location_list_name]['locations']
+        )
+
+    assert location.get_location_ids(["NZ", "SRWG214"]) == (
+        location.LOCATION_LISTS["NZ"]["locations"] + location.LOCATION_LISTS["SRWG214"]["locations"]
+    )
 
     with pytest.raises(KeyError):
-        location.get_location_ids("INVALID_NAME")
+        location.get_location_ids(["INVALID_NAME"])
+
+
+def test_get_location_dicts():
+    nz_locations = location.get_location_dicts(["NZ"])
+    assert len(nz_locations) == 36
+    ids = [loc['id'] for loc in nz_locations]
+    assert "WLG" in ids
+    assert nz_locations[ids.index("WLG")] == location.location_by_id("WLG")
+
+    with pytest.raises(KeyError):
+        location.get_location_ids(["INVALID_NAME"])

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -18,7 +18,7 @@ def test_location_lists():
 def test_vs30():
     for id in location.LOCATION_LISTS["HB"]["locations"]:
         assert location.LOCATIONS_BY_ID[id].get("vs30")
-    assert location.LOCATIONS_BY_ID[f"hb_{2603-2}"]["vs30"] == 150
+    assert location.LOCATIONS_BY_ID[f"hb_{2603 - 2}"]["vs30"] == 150
 
 
 def test_location_rot():
@@ -82,3 +82,11 @@ def test_word_mapping():
 )
 def test_macron_mapping(name_in, name_out):
     assert location.get_name_with_macrons(name_in) == name_out
+
+
+def test_get_location_ids():
+    for location_list_name in location.get_location_list_names():
+        assert location.get_location_ids(location_list_name) == location.LOCATION_LISTS[location_list_name]['locations']
+
+    with pytest.raises(KeyError):
+        location.get_location_ids("INVALID_NAME")

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -98,12 +98,12 @@ def test_get_location_ids():
         location.get_location_ids(["INVALID_NAME"])
 
 
-def test_get_location_dicts():
-    nz_locations = location.get_location_dicts(["NZ"])
+def test_get_location_data():
+    nz_locations = location.get_location_data(["NZ"])
     assert len(nz_locations) == 36
-    ids = [loc['id'] for loc in nz_locations]
+    ids = [loc.id for loc in nz_locations]
     assert "WLG" in ids
-    assert nz_locations[ids.index("WLG")] == location.location_by_id("WLG")
+    assert nz_locations[ids.index("WLG")] == location.Location(**(location.location_by_id("WLG")))
 
     with pytest.raises(KeyError):
         location.get_location_ids(["INVALID_NAME"])


### PR DESCRIPTION
closes #60 

I decided on a simple approach of two helper functions.
- `get_location_ids` gives a list of location ids for the input location list names.
- `get_location_dicts` gives the list of dicts with full location information for the input location list names. The dicts are what are returned by `location_by_id` and have id, name, and coordinates.

Open to suggestions for different function name for `get_location_dicts`.

These functions were added because I often found myself doing something like this when creating plots with location labels:
```
location_ids = LOCATION_LISTS['NZ']['locations']
cities = get_locations(location_ids)
cities_lon = [loc.lon for loc in cities]
cities_lat = [loc.lat for loc in cities]
cities_name = [location_by_id(loc)['name'] for loc in location_ids]
```
