### PR TITLE
Speedup get location grid

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.3
+current_version = 0.9.4
 commit = True
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.3] 2026-03-27
+## [0.9.4] 2026-03-27
 
 ### Changed
   - new algorithm to deduplicate location list in `get_location_grid` function results in faster performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] 2026-03-27
+
+### Changed
+  - new algorithm to deduplicate location list in `get_location_grid` function results in faster performance
+
 ## [0.9.3] 2026-03-20
 ### Changed
  - upgrade dependencies

--- a/nzshm_common/__init__.py
+++ b/nzshm_common/__init__.py
@@ -1,6 +1,6 @@
 __author__ = "GNS Science"
 __email__ = 'nshm@gns.cri.nz'
-__version__ = '0.9.3'
+__version__ = '0.9.4'
 
 
 # Common classes at the top level for convenience

--- a/nzshm_common/grids/region_grid.py
+++ b/nzshm_common/grids/region_grid.py
@@ -1,7 +1,6 @@
 import warnings
 from collections import namedtuple
 from enum import Enum
-from functools import partial
 from typing import Iterable, List, Optional, cast
 
 from nzshm_common.grids.nz_0_1_nb_1_v0 import NZ01nb1v0
@@ -97,14 +96,9 @@ def get_location_grid(location_grid_name: str, resolution: Optional[float] = Non
         warnings.warn(warn_msg, stacklevel=2)
 
     grid_values = load_grid(location_grid_name)
-    coded_at_resolution = partial(CodedLocation.from_tuple, resolution=cast(float, resolution))
+    location_list = [CodedLocation.from_tuple(gv, resolution=cast(float, resolution)) for gv in grid_values]
     # Remove duplicate coordinates from collection, preserving order.
-    location_list = []
-    for loc in map(coded_at_resolution, grid_values):
-        if loc not in location_list:
-            location_list.append(loc)
-
-    return location_list
+    return list(dict.fromkeys(location_list))
 
 
 def get_location_grid_names() -> Iterable[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nzshm-common"
-version = "0.9.3"
+version = "0.9.4"
 description = "A small pure python library for shared NZ NSHM data like locations."
 readme = "README.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
~50x improvement in the time to run `get_location_grid('NZ_0_1_NB_1_1')`

```
import timeit
from nzshm_common.grids import get_location_grid

def aquire_grid():
    return get_location_grid('NZ_0_1_NB_1_1')

N = 3
execution_time = timeit.timeit(aquire_grid, number=N)
print(f"Average execution time over {N} runs: {execution_time / N} seconds")
```

## main:
```
$ poetry run python ./scratch/time_grids.py 
Average execution time over 3 runs: 6.677420764307802 seconds
```

## this branch:
```
$ poetry run python ./scratch/time_grids.py 
Average execution time over 3 runs: 0.13082696699226895 seconds
```